### PR TITLE
Feature creating single event page

### DIFF
--- a/events/kids-youth-festival.json
+++ b/events/kids-youth-festival.json
@@ -1,0 +1,29 @@
+{
+  "title": "Kids & Youth Festival!",
+  "date": "Aug 20, 2024 @ 10:00 am - Sep 9, 2024 @ 3:30pm",
+  "image": {
+    "url": "https://source.unsplash.com/random/1200x400",
+    "alt": "Random image from Unsplash"
+  },
+  "content": "# Markdown content goes here\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean fringilla odio sed eros tempus mollis eu a justo. Sed est nulla, placerat a feugiat et, blandit non urna. Nunc quis vehicula libero. Proin varius tempor lectus non gravida. Quisque et facilisis mi. Nullam sodales facilisis mi nec iaculis. Quisque a arcu euismod sem iaculis laoreet.\n- Hello\n- World\n> Bruh",
+  "details": {
+    "start": "Aug 20, 2024 @ 10:00 am",
+    "end": "Sep 9, 2024 @ 3:30pm",
+    "cost": "$270",
+    "category": "Festival"
+  },
+  "organizer": {
+    "name": "Ashton Porter",
+    "phone": "88001234567",
+    "email": "info@example.com",
+    "website": "https://example.com"
+  },
+  "venue": {
+    "name": "Manhattan Club",
+    "address": "350 5th Ave, New York, NY 10118 United States",
+    "addressURL": "https://goo.gl/maps/snNWPNNH6ea8XoZq8",
+    "addressEmbed": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3022.6055184203096!2d-73.98503393914793!3d40.748704975273405!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c259a9b30eac9f%3A0xaca05ca48ab5ac2c!2s350%205th%20Ave%2C%20New%20York%2C%20NY%2010118%2C%20USA!5e0!3m2!1sen!2sca!4v1691963639707!5m2!1sen!2sca",
+    "phone": "88001234567",
+    "website": "https://example.com"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.9",
         "tailwindcss": "^3.3.3"
       }
     },
@@ -101,6 +102,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.9.tgz",
+      "integrity": "sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==",
+      "dev": true,
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/any-promise": {
@@ -463,6 +492,24 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.9",
     "tailwindcss": "^3.3.3"
   }
 }

--- a/single-event-api-base.html
+++ b/single-event-api-base.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Arise Website</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="icon" href="./images/favicon.ico" type="image/x-icon">
+</head>
+
+<body>
+  <!-- HEADER/NAVBAR -->
+
+  <main>
+    <div class="container mx-auto my-10 px-5 flex flex-col gap-4">
+      <h1 class="text-5xl font-bold text-center" id="title"></h1>
+      <div class="flex items-center gap-x-4 text-xs place-content-center">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5m-9-6h.008v.008H12v-.008zM12 15h.008v.008H12V15zm0 2.25h.008v.008H12v-.008zM9.75 15h.008v.008H9.75V15zm0 2.25h.008v.008H9.75v-.008zM7.5 15h.008v.008H7.5V15zm0 2.25h.008v.008H7.5v-.008zm6.75-4.5h.008v.008h-.008v-.008zm0 2.25h.008v.008h-.008V15zm0 2.25h.008v.008h-.008v-.008zm2.25-4.5h.008v.008H16.5v-.008zm0 2.25h.008v.008H16.5V15z" />
+        </svg>
+        <p class="text-gray-500" id="date"></p>
+      </div>
+      <img class="rounded" id="image">
+      <article class="prose text-gray-600 w-full" id="content"></article>
+      <div class="flex flex-wrap gap-y-4 gap-x-10 mt-10">
+        <div class="flex-1 space-y-4 w-64">
+          <h2 class="text-3xl font-bold">Details</h2>
+          <div>
+            <p class="font-bold">Start:</p>
+            <p class="text-gray-600" id="start"></p>
+          </div>
+          <div>
+            <p class="font-bold">End:</p>
+            <p class="text-gray-600" id="end"></p>
+          </div>
+          <div>
+            <p class="font-bold">Cost:</p>
+            <p class="text-gray-600" id="cost"></p>
+          </div>
+          <div>
+            <p class="font-bold">Event Category:</p>
+            <p class="text-gray-600" id="category"></p>
+          </div>
+        </div>
+        <div class="flex-1 space-y-4 w-64">
+          <h2 class="text-3xl font-bold">Organizer</h2>
+          <div>
+            <p class="text-gray-600" id="organizerName"></p>
+          </div>
+          <div>
+            <p class="font-bold">Phone:</p>
+            <a class="text-gray-600" id="organizerPhone"></a>
+          </div>
+          <div>
+            <p class="font-bold">Email:</p>
+            <p class="text-gray-600" id="organizerEmail"></p>
+          </div>
+          <div>
+            <a class="text-gray-600" id="organizerWebsite">View Organizer website</a>
+          </div>
+        </div>
+        <div class="flex-1 space-y-4 w-64">
+          <h2 class="text-3xl font-bold">Venue</h2>
+          <div>
+            <p class="text-gray-600" id="venueName"></p>
+          </div>
+          <div>
+            <a id="venueAddress"></a>
+          </div>
+          <div>
+            <p class="font-bold">Phone:</p>
+            <a class="text-gray-600" id="venuePhone"></a>
+          </div>
+          <div>
+            <a class="text-gray-600" id="venueWebsite">View Venue website</a>
+          </div>
+        </div>
+        <div class="flex-1 space-y-4 w-96">
+          <iframe class="w-full" id="mapIframe" width="600" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+
+  <script src="./scripts/index.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    async function renderPage() {
+      const response = await fetch(buildEventDetailsURL()).catch(() => {
+        return {
+          ok: false
+        }
+      });
+      if (!response.ok) {
+        location.href = './404.html';
+        return;
+      }
+
+      const event = await response.json();
+      updateComponents(event);
+    }
+
+    // Builds the URL for the event details JSON file.
+    function buildEventDetailsURL() {
+      const slug = location.hash.slice(1);
+
+      // TODO: Remove before production. Only for development purposes.
+      if (slug === '') {
+        return `./events/kids-youth-festival.json`;
+      }
+
+      // For now, we'll just GitHub as our API.
+      return `./events/${slug}.json`;
+    }
+
+    function updateComponents(event) {
+      document.title = event.title;
+      document.getElementById('title').textContent = event.title;
+      document.getElementById('date').textContent = event.date;
+      document.getElementById('image').src = event.image.url;
+      document.getElementById('image').alt = event.image.alt;
+      // Markdown is not rendered correctly at the moment due to using the CDN version of Tailwind, but once we build the final CSS file, it should work with the @tailwindcss/typography plugin.
+      document.getElementById('content').innerHTML = marked.parse(event.content);
+
+      document.getElementById('start').textContent = event.details.start;
+      document.getElementById('end').textContent = event.details.end;
+      document.getElementById('cost').textContent = event.details.cost;
+      document.getElementById('category').textContent = event.details.category;
+
+      document.getElementById('organizerName').textContent = event.organizer.name;
+      document.getElementById('organizerPhone').textContent = event.organizer.phone;
+      document.getElementById('organizerPhone').href = `tel:${event.organizer.phone}`;
+      document.getElementById('organizerEmail').textContent = event.organizer.email;
+      document.getElementById('organizerEmail').href = `mailto:${event.organizer.email}`;
+      document.getElementById('organizerWebsite').href = event.organizer.website;
+
+      document.getElementById('venueName').textContent = event.venue.name;
+      document.getElementById('venueAddress').textContent = event.venue.address;
+      document.getElementById('venueAddress').href = event.venue.addressURL;
+      document.getElementById('venuePhone').textContent = event.venue.phone;
+      document.getElementById('venuePhone').href = `tel:${event.venue.phone}`;
+      document.getElementById('venueWebsite').href = event.organizer.website;
+      document.getElementById('mapIframe').src = event.venue.addressEmbed;
+    }
+
+    renderPage();
+  </script>
+</body>
+
+</html>

--- a/single-event.html
+++ b/single-event.html
@@ -14,7 +14,7 @@
   <!-- HEADER/NAVBAR -->
 
   <main>
-    <div class="container mx-auto m-10 flex flex-col gap-4">
+    <div class="container mx-auto my-10 px-5 flex flex-col gap-4">
       <h1 class="text-5xl font-bold text-center">Kids & Youth Festival!</h1>
       <div class="flex items-center gap-x-4 text-xs place-content-center">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
@@ -22,7 +22,7 @@
         </svg>
         <p class="text-gray-500">Aug 20, 2024 @ 10:00 am - Sep 9, 2024 @ 3:30pm</p>
       </div>
-      <img src="https://source.unsplash.com/random/1200x400" alt="Alt text" />
+      <img src="https://source.unsplash.com/random/1200x400" class="rounded" alt="Random image from unsplash">
       <p class="text-gray-600">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sed semper lectus, sed vulputate tortor.
         Pellentesque porta leo ut gravida tincidunt. Mauris odio nisi, euismod in auctor nec, accumsan vitae ex. Proin
@@ -32,7 +32,7 @@
         Donec mollis enim eu odio consequat, a egestas nunc luctus. Phasellus dictum, massa ut tempor placerat, massa
         erat eleifend justo, a euismod nunc enim ac risus.
         
-        <br /><br />
+        <br><br>
 
         Sed lacinia ullamcorper lectus dictum volutpat. Fusce accumsan at lectus ac semper. Sed consequat sed sapien in
         fermentum. Integer elementum arcu id eros dapibus, et dictum lorem hendrerit. Sed vitae efficitur dui. Sed et
@@ -43,7 +43,7 @@
         Integer eu mi semper, venenatis enim sit amet, ultricies odio. Maecenas est ex, sagittis et consequat at,
         venenatis vel dolor.
 
-        <br /><br />
+        <br><br>
 
         Donec eu purus gravida, lobortis quam ut, eleifend dolor. Quisque vestibulum ex sapien, at luctus ligula laoreet
         id. Maecenas et gravida nisi. Phasellus pharetra gravida lectus, vitae fermentum elit molestie eu. Morbi
@@ -53,6 +53,67 @@
         urna non sapien sollicitudin vehicula vel vel erat. Vestibulum est ante, vehicula vitae sagittis eget,
         scelerisque vel nunc.
       </p>
+      <div class="flex flex-wrap gap-y-4 gap-x-10 mt-10">
+        <div class="flex-1 space-y-4 w-64">
+          <h2 class="text-3xl font-bold">Details</h2>
+          <div>
+            <p class="font-bold">Start:</p>
+            <p class="text-gray-600">Aug 20, 2024 @ 10:00 am</p>  
+          </div>
+          <div>
+            <p class="font-bold">End:</p>
+            <p class="text-gray-600">Sep 9, 2024 @ 3:30pm</p>
+          </div>
+          <div>
+            <p class="font-bold">Cost:</p>
+            <p class="text-gray-600">$270</p>
+          </div>
+          <div>
+            <p class="font-bold">Event Category:</p>
+            <p class="text-gray-600">Festival</p>
+          </div>
+        </div>
+        <div class="flex-1 space-y-4 w-64">
+          <h2 class="text-3xl font-bold">Organizer</h2>
+          <div>
+            <p class="text-gray-600">Ashton Porter</p>    
+          </div>
+          <div>
+            <p class="font-bold">Phone:</p>
+            <a class="text-gray-600" href="tel:88001234567">88001234567</a>
+          </div>
+          <div>
+            <p class="font-bold">Email:</p>
+            <p class="text-gray-600" href="mailto:info@example.com">info@example.com</p>
+          </div>
+          <div>
+            <a class="text-gray-600" href="#">View Organizer website</a>
+          </div>
+        </div>
+        <div class="flex-1 space-y-4 w-64">
+          <h2 class="text-3xl font-bold">Venue</h2>
+          <div>
+            <p class="text-gray-600">Manhattan Club</p>    
+          </div>
+          <div>
+            <a href="https://goo.gl/maps/snNWPNNH6ea8XoZq8">
+              350 5th Ave
+              <br>
+              New York, NY 10118 United States
+            </a>
+          </div>
+          <div>
+            <p class="font-bold">Phone:</p>
+            <a class="text-gray-600" href="tel:88001234567">88001234567</a>
+          </div>
+          <div>
+            <a class="text-gray-600" href="#">View Venue website</a>
+          </div>
+        </div>
+        <div class="flex-1 space-y-4 w-96">
+          <iframe class="w-full" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3022.6055184203096!2d-73.98503393914793!3d40.748704975273405!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c259a9b30eac9f%3A0xaca05ca48ab5ac2c!2s350%205th%20Ave%2C%20New%20York%2C%20NY%2010118%2C%20USA!5e0!3m2!1sen!2sca!4v1691963639707!5m2!1sen!2sca" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        </div>
+      </div>
     </div>
   </main>
 

--- a/single-event.html
+++ b/single-event.html
@@ -1,1 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
 
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Arise Website</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="icon" href="./images/favicon.ico" type="image/x-icon">
+</head>
+
+<body>
+  <!-- HEADER/NAVBAR -->
+
+  <main>
+    <div class="container mx-auto m-10 flex flex-col gap-4">
+      <h1 class="text-5xl font-bold text-center">Kids & Youth Festival!</h1>
+      <div class="flex items-center gap-x-4 text-xs place-content-center">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5m-9-6h.008v.008H12v-.008zM12 15h.008v.008H12V15zm0 2.25h.008v.008H12v-.008zM9.75 15h.008v.008H9.75V15zm0 2.25h.008v.008H9.75v-.008zM7.5 15h.008v.008H7.5V15zm0 2.25h.008v.008H7.5v-.008zm6.75-4.5h.008v.008h-.008v-.008zm0 2.25h.008v.008h-.008V15zm0 2.25h.008v.008h-.008v-.008zm2.25-4.5h.008v.008H16.5v-.008zm0 2.25h.008v.008H16.5V15z" />
+        </svg>
+        <p class="text-gray-500">Aug 20, 2024 @ 10:00 am - Sep 9, 2024 @ 3:30pm</p>
+      </div>
+      <img src="https://source.unsplash.com/random/1200x400" alt="Alt text" />
+      <p class="text-gray-600">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sed semper lectus, sed vulputate tortor.
+        Pellentesque porta leo ut gravida tincidunt. Mauris odio nisi, euismod in auctor nec, accumsan vitae ex. Proin
+        sed commodo erat. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+        Quisque laoreet urna enim, et iaculis lorem efficitur sit amet. Quisque congue maximus scelerisque. Cras dapibus
+        nulla et massa dignissim aliquam. Nullam arcu sem, fermentum sit amet suscipit at, posuere sit amet libero.
+        Donec mollis enim eu odio consequat, a egestas nunc luctus. Phasellus dictum, massa ut tempor placerat, massa
+        erat eleifend justo, a euismod nunc enim ac risus.
+        
+        <br /><br />
+
+        Sed lacinia ullamcorper lectus dictum volutpat. Fusce accumsan at lectus ac semper. Sed consequat sed sapien in
+        fermentum. Integer elementum arcu id eros dapibus, et dictum lorem hendrerit. Sed vitae efficitur dui. Sed et
+        orci a ipsum sodales accumsan sed sit amet nisl. Orci varius natoque penatibus et magnis dis parturient montes,
+        nascetur ridiculus mus. Sed finibus lacus ante, a auctor nisi gravida ut. Nunc hendrerit tristique ex quis
+        dapibus. Cras elit dolor, cursus ac maximus at, ullamcorper a dolor. Quisque non faucibus turpis. Aliquam eget
+        orci et quam sollicitudin facilisis viverra vel dui. Nam mi massa, posuere nec mollis eget, lacinia ac leo.
+        Integer eu mi semper, venenatis enim sit amet, ultricies odio. Maecenas est ex, sagittis et consequat at,
+        venenatis vel dolor.
+
+        <br /><br />
+
+        Donec eu purus gravida, lobortis quam ut, eleifend dolor. Quisque vestibulum ex sapien, at luctus ligula laoreet
+        id. Maecenas et gravida nisi. Phasellus pharetra gravida lectus, vitae fermentum elit molestie eu. Morbi
+        tristique odio lorem, id gravida ex gravida id. Proin molestie dapibus tellus, sit amet mattis felis efficitur
+        dictum. Donec tristique pharetra porttitor. Nullam ultricies velit id mattis volutpat. Maecenas ut risus
+        dignissim, convallis turpis ut, fringilla ligula. Etiam commodo velit ultrices iaculis tincidunt. Maecenas vitae
+        urna non sapien sollicitudin vehicula vel vel erat. Vestibulum est ante, vehicula vitae sagittis eget,
+        scelerisque vel nunc.
+      </p>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+
+  <script src="./scripts/index.js"></script>
+</body>
+
+</html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,13 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [],
+  content: [
+    "./**/*.{html,js}"
+  ],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
 }
 


### PR DESCRIPTION
Created two pages based on the samples given in issue #28. The first page is static with everything hardcoded to to the file, and the second page uses a mock API to fetch the event details. Since there is no backend at the moment, I decided to use the url fragment/hash to specify which post to fetch and used GitHub directly for storing event details in the events folder. If published like this, event json files can be viewed by visiting https://arise-club.github.io/website/single-event-api-base.html#name-of-the-event-file. I have already created a sample event, and its url would be https://arise-club.github.io/website/single-event-api-base.html#kids-youth-festival. Closes #28 